### PR TITLE
feat: 支持多级 m3u8 递归解析

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -183,8 +183,8 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
       if (!(await fs.pathExists(path.dirname(this.output)))) {
         throw new Error("Output directory does not exist");
       }
-      const m3u8Content = await this.getM3U8();
-      const urls = this.parseM3U8(m3u8Content);
+      const m3u8= await this.getM3U8();
+      const urls = this.parseM3U8(m3u8.content, m3u8.url);
 
       this.totalSegments = urls.length;
 
@@ -243,16 +243,110 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
     this.queue.clear();
   }
 
+
+
   /**
    * download M3U8 file
+   * Resolve a master playlist into the concrete media playlist that contains
    */
-  private async getM3U8(): Promise<string> {
+  private async getM3U8(
+    maxDepth = 5
+  ): Promise<{ content: string; url: string }> {
+    const visited = new Set<string>();
+
+    const walk = async (
+      currentUrl: string,
+      depth: number
+    ): Promise<{ content: string; url: string }> => {
+      if (!currentUrl) {
+        throw new Error("Playlist URL is empty");
+      }
+      if (depth > maxDepth) {
+        throw new Error(`Playlist depth exceeded maxDepth=${maxDepth}`);
+      }
+      if (visited.has(currentUrl)) {
+        throw new Error(`Playlist loop detected: ${currentUrl}`);
+      }
+
+      visited.add(currentUrl);
+
+      const { data } = await this.http.get<string>(currentUrl, {
+        responseType: "text",
+      });
+      const text = String(data ?? "").trim();
+      if (!text) {
+        throw new Error(`Playlist response is empty: ${currentUrl}`);
+      }
+
+      const parser = new m3u8Parser.Parser();
+      parser.push(text);
+      parser.end();
+
+      const manifest = parser.manifest as {
+        segments?: Array<{ uri: string; duration: number }>;
+        playlists?: Array<{
+          uri?: string;
+          attributes?: { BANDWIDTH?: number };
+        }>;
+        media?: Array<{ uri?: string }>;
+      };
+
+      if ((manifest.segments?.length ?? 0) > 0) {
+        return { content: text, url: currentUrl };
+      }
+
+      const nextUrl = this.pickNextPlaylistUrl(currentUrl, manifest);
+      if (!nextUrl) {
+        throw new Error(`No nested media playlist found: ${currentUrl}`);
+      }
+
+      return walk(nextUrl, depth + 1);
+    };
+
+    return walk(this.m3u8Url, 0);
+  }
+
+  private pickNextPlaylistUrl(
+    baseUrl: string,
+    manifest: {
+      playlists?: Array<{
+        uri?: string;
+        attributes?: { BANDWIDTH?: number };
+      }>;
+      media?: Array<{ uri?: string }>;
+    }
+  ): string {
+    const streamCandidates = (manifest.playlists ?? [])
+      .map(playlist => ({
+        bandwidth: Number(playlist.attributes?.BANDWIDTH ?? 0),
+        url: this.resolvePlaylistUrl(baseUrl, playlist.uri),
+      }))
+      .filter(
+        (candidate): candidate is { bandwidth: number; url: string } =>
+          candidate.url.length > 0
+      );
+
+    if (streamCandidates.length > 0) {
+      streamCandidates.sort((a, b) => b.bandwidth - a.bandwidth);
+      return streamCandidates[0].url;
+    }
+
+    const mediaCandidates = (manifest.media ?? [])
+      .map(media => this.resolvePlaylistUrl(baseUrl, media.uri))
+      .filter((url): url is string => url.length > 0);
+
+    return mediaCandidates[0] ?? "";
+  }
+
+  private resolvePlaylistUrl(baseUrl: string, childUrl?: string): string {
+    if (!childUrl) {
+      return "";
+    }
+
     try {
-      const { data: m3u8Content } = await this.http.get(this.m3u8Url);
-      return m3u8Content;
-    } catch (error) {
-      this.emit("error", "Failed to download m3u8 file");
-      throw error;
+      return new URL(childUrl, baseUrl).toString();
+    } catch {
+      return "";
     }
   }
 
@@ -260,7 +354,10 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
    * parse M3U8 file and return an array of URLs
    * @param m3u8Content M3U8 file content
    */
-  private parseM3U8(m3u8Content: string): string[] {
+  private parseM3U8(
+    m3u8Content: string,
+    baseUrl: string = this.m3u8Url
+  ): string[] {
     const parser = new m3u8Parser.Parser();
 
     parser.push(m3u8Content);
@@ -306,12 +403,10 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
     return segments.map(segment => {
       if (isUrl(segment.uri)) {
         return segment.uri;
-      } else {
-        return new URL(segment.uri, this.m3u8Url).href;
       }
+      return new URL(segment.uri, baseUrl).href;
     });
   }
-
   private async downloadSegment(tsUrl: string, index: number) {
     if (!this.isRunning()) return;
     const formattedIndex = String(index).padStart(5, "0");
@@ -501,3 +596,4 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
     return this.status === "running";
   }
 }
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -295,18 +295,29 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
         return { content: text, url: currentUrl };
       }
 
-      const nextUrl = this.pickNextPlaylistUrl(currentUrl, manifest);
-      if (!nextUrl) {
+      const nextUrls = this.pickNextPlaylistUrls(currentUrl, manifest);
+      if (nextUrls.length === 0) {
         throw new Error(`No nested media playlist found: ${currentUrl}`);
       }
 
-      return walk(nextUrl, depth + 1);
+      let lastError: unknown;
+      for (const nextUrl of nextUrls) {
+        try {
+          return await walk(nextUrl, depth + 1);
+        } catch (error) {
+          lastError = error;
+        }
+      }
+
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(`All nested playlist candidates failed: ${currentUrl}`);
     };
 
     return walk(this.m3u8Url, 0);
   }
 
-  private pickNextPlaylistUrl(
+  private pickNextPlaylistUrls(
     baseUrl: string,
     manifest: {
       playlists?: Array<{
@@ -315,7 +326,7 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
       }>;
       media?: Array<{ uri?: string }>;
     }
-  ): string {
+  ): string[] {
     const streamCandidates = (manifest.playlists ?? [])
       .map(playlist => ({
         bandwidth: Number(playlist.attributes?.BANDWIDTH ?? 0),
@@ -328,14 +339,12 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
 
     if (streamCandidates.length > 0) {
       streamCandidates.sort((a, b) => b.bandwidth - a.bandwidth);
-      return streamCandidates[0].url;
+      return streamCandidates.map(candidate => candidate.url);
     }
 
-    const mediaCandidates = (manifest.media ?? [])
+    return (manifest.media ?? [])
       .map(media => this.resolvePlaylistUrl(baseUrl, media.uri))
       .filter((url): url is string => url.length > 0);
-
-    return mediaCandidates[0] ?? "";
   }
 
   private resolvePlaylistUrl(baseUrl: string, childUrl?: string): string {
@@ -596,4 +605,3 @@ export default class M3U8Downloader extends TypedEmitter<M3U8DownloaderEvents> {
     return this.status === "running";
   }
 }
-

--- a/test/express.ts
+++ b/test/express.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import type { Server } from "node:http";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,6 +7,7 @@ export const __dirname = dirname(fileURLToPath(import.meta.url));
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 const app = express();
+let server: Server | null = null;
 
 app.get("/", (req, res) => {
   res.send("Hello World!");
@@ -53,6 +55,33 @@ app.get("/multi/media/video.m3u8", (req, res) => {
 #EXT-X-ENDLIST`);
 });
 
+app.get("/fallback/master.m3u8", (req, res) => {
+  res.send(`
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=5000000,RESOLUTION=1920x1080
+broken/1080.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=1800000,RESOLUTION=1280x720
+valid/720.m3u8
+`);
+});
+
+app.get("/fallback/broken/1080.m3u8", (req, res) => {
+  res.status(404).send("missing");
+});
+
+app.get("/fallback/valid/720.m3u8", (req, res) => {
+  res.send(`
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:10.0,
+../../segment0.ts
+#EXTINF:10.0,
+../../segment1.ts
+#EXT-X-ENDLIST`);
+});
+
 app.get("/head/video.m3u8", (req, res) => {
   res.send(req.headers);
 });
@@ -86,9 +115,15 @@ app.get("/:file", async (req, res) => {
 });
 
 export const serverStart = () => {
-  app.listen(3000, () => {
+  if (server) {
+    return server;
+  }
+
+  server = app.listen(3000, () => {
     console.log("Server is running on port 3000");
   });
+
+  return server;
 };
 
 // serverStart();

--- a/test/express.ts
+++ b/test/express.ts
@@ -23,6 +23,36 @@ segment0.ts
 segment1.ts
 #EXT-X-ENDLIST`);
 });
+
+app.get("/multi/master.m3u8", (req, res) => {
+  res.send(`
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=800000,RESOLUTION=640x360
+level1/index.m3u8
+`);
+});
+
+app.get("/multi/level1/index.m3u8", (req, res) => {
+  res.send(`
+#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=1800000,RESOLUTION=1280x720
+../media/video.m3u8
+`);
+});
+
+app.get("/multi/media/video.m3u8", (req, res) => {
+  res.send(`
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:10.0,
+../../segment0.ts
+#EXTINF:10.0,
+../../segment1.ts
+#EXT-X-ENDLIST`);
+});
+
 app.get("/head/video.m3u8", (req, res) => {
   res.send(req.headers);
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,6 +20,7 @@ const safeRm = (path: string) => {
 
 describe("M3U8Downloader", () => {
   const m3u8Url = "http://127.0.0.1:3000/video.m3u8";
+  const multiLevelM3u8Url = "http://127.0.0.1:3000/multi/master.m3u8";
   const output = "/path/to/output.mp4";
   const segmentsDir = path.join(os.tmpdir(), "m3u8-downloader");
   if (!fs.existsSync(segmentsDir)) {
@@ -35,7 +36,27 @@ describe("M3U8Downloader", () => {
       const downloader = new M3U8Downloader(m3u8Url, output) as any;
       const data = await axios.get(m3u8Url);
       const data2 = await downloader.getM3U8();
-      expect(data.data).toEqual(data2);
+      expect(data2).toEqual({
+        content: data.data.trim(),
+        url: m3u8Url,
+      });
+    });
+    it("should resolve a nested master playlist to the real media playlist", async () => {
+      const downloader = new M3U8Downloader(multiLevelM3u8Url, output) as any;
+      const data = await downloader.getM3U8();
+
+      expect(data).toEqual({
+        content: `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:10.0,
+../../segment0.ts
+#EXTINF:10.0,
+../../segment1.ts
+#EXT-X-ENDLIST`,
+        url: "http://127.0.0.1:3000/multi/media/video.m3u8",
+      });
     });
     it("should set the custom header", async () => {
       const m3u8Url = "http://127.0.0.1:3000/head/video.m3u8";
@@ -45,7 +66,7 @@ describe("M3U8Downloader", () => {
           "user-agent": "axios",
         },
       }) as any;
-      const data = await downloader.getM3U8();
+      const { data } = await downloader.http.get(m3u8Url);
       expect(data["custom-header"]).toEqual("custom-value");
       expect(data["user-agent"]).toEqual("axios");
     });
@@ -182,6 +203,30 @@ describe("M3U8Downloader", () => {
 
       onTestFinished(() => {
         // clean
+        safeRm(segmentsDir);
+      });
+    });
+    it("should download success from a nested master playlist", async ({
+      onTestFinished,
+    }) => {
+      const segmentsDir = path.join(os.tmpdir(), "m3u8-downloader", uuid());
+      const output = path.join(segmentsDir, "output.ts");
+
+      const downloader = new M3U8Downloader(multiLevelM3u8Url, output, {
+        convert2Mp4: false,
+        segmentsDir,
+        clean: true,
+      });
+
+      await downloader.download();
+      await sleep(100);
+
+      expect(downloader.status).toEqual("completed");
+      expect(fs.existsSync(output)).toBeTruthy();
+      expect(fs.readFileSync(output).length).toEqual(8868524);
+
+      onTestFinished(() => {
+        safeRm(output);
         safeRm(segmentsDir);
       });
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,6 +21,7 @@ const safeRm = (path: string) => {
 describe("M3U8Downloader", () => {
   const m3u8Url = "http://127.0.0.1:3000/video.m3u8";
   const multiLevelM3u8Url = "http://127.0.0.1:3000/multi/master.m3u8";
+  const fallbackM3u8Url = "http://127.0.0.1:3000/fallback/master.m3u8";
   const output = "/path/to/output.mp4";
   const segmentsDir = path.join(os.tmpdir(), "m3u8-downloader");
   if (!fs.existsSync(segmentsDir)) {
@@ -56,6 +57,23 @@ describe("M3U8Downloader", () => {
 ../../segment1.ts
 #EXT-X-ENDLIST`,
         url: "http://127.0.0.1:3000/multi/media/video.m3u8",
+      });
+    });
+    it("should fallback to the next variant when the highest bandwidth playlist fails", async () => {
+      const downloader = new M3U8Downloader(fallbackM3u8Url, output) as any;
+      const data = await downloader.getM3U8();
+
+      expect(data).toEqual({
+        content: `#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-TARGETDURATION:10
+#EXT-X-MEDIA-SEQUENCE:0
+#EXTINF:10.0,
+../../segment0.ts
+#EXTINF:10.0,
+../../segment1.ts
+#EXT-X-ENDLIST`,
+        url: "http://127.0.0.1:3000/fallback/valid/720.m3u8",
       });
     });
     it("should set the custom header", async () => {
@@ -213,6 +231,30 @@ describe("M3U8Downloader", () => {
       const output = path.join(segmentsDir, "output.ts");
 
       const downloader = new M3U8Downloader(multiLevelM3u8Url, output, {
+        convert2Mp4: false,
+        segmentsDir,
+        clean: true,
+      });
+
+      await downloader.download();
+      await sleep(100);
+
+      expect(downloader.status).toEqual("completed");
+      expect(fs.existsSync(output)).toBeTruthy();
+      expect(fs.readFileSync(output).length).toEqual(8868524);
+
+      onTestFinished(() => {
+        safeRm(output);
+        safeRm(segmentsDir);
+      });
+    });
+    it("should fallback to a lower bandwidth playlist during download", async ({
+      onTestFinished,
+    }) => {
+      const segmentsDir = path.join(os.tmpdir(), "m3u8-downloader", uuid());
+      const output = path.join(segmentsDir, "output.ts");
+
+      const downloader = new M3U8Downloader(fallbackM3u8Url, output, {
         convert2Mp4: false,
         segmentsDir,
         clean: true,


### PR DESCRIPTION
有些m3u8 文件不是 ts 分片列表，而是指向下一层 m3u8 播放列表，这个还可能是多层。
现在只能读取一层，试了下代码没问题。


实现逻辑是先用 m3u8-parser 解析当前 m3u8
若 manifest.segments 有值则说明已到真实 ts 列表
若没有 则继续从 manifest 中取下一层 m3u8 地址递归解析。

包含多个分辨率的情况默认选择分辨率最高的，如果解析失败会再次解析下一个分辨率的地址。